### PR TITLE
Fixed missing opencv interface in CMakeLists

### DIFF
--- a/gl_depth_sim/CMakeLists.txt
+++ b/gl_depth_sim/CMakeLists.txt
@@ -45,7 +45,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 
 # Libaries for interfacing with opencv and pcl
 add_library(${PROJECT_NAME}_interfaces SHARED
-  src/interfaces/pcl_interface.cpp)
+  src/interfaces/pcl_interface.cpp 
+  src/interfaces/opencv_interface.cpp)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"


### PR DESCRIPTION
Currently, building `roscpp_gl_depth_sim_demos` throws a linker error that fails to resolve `gl_depth_sim::toCvImage16u`

```
camera_example.cpp(.text.startup+0x129e): undefined reference to `gl_depth_sim::toCvImage16u(gl_depth_sim::DepthImage const&, cv::Mat&)'
collect2: error: ld returned 1 exit status
```
Tracked down the issue to a deleted line in `CMakeLists.txt` that references `opencv_interface` where the function is defined.
Re-adding `opencv_inferface` allows the demos to compile without error.