### PR TITLE
Set OpenGL_GL_Preference to LEGACY

### DIFF
--- a/gl_depth_sim/CMakeLists.txt
+++ b/gl_depth_sim/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED common io)
 
 find_package(OpenCV REQUIRED)
-SET(OpenGL_GL_PREFERENCE "GLVND")
+SET(OpenGL_GL_PREFERENCE LEGACY)
 
 #find_package(Threads REQUIRED)
 #set(THREADS_PREFER_PTHREAD_FLAG ON)


### PR DESCRIPTION
Setting `OpenGL_GL_Preference` requires either `LEGACY` or `GLVND` without quotation marks.

Currently, when building `roscpp_gl_depth_sim_demos` (after #2 is applied), CMake warns that `OpenGL_GL_Preference` is unset and defaults to `LEGACY` since it does not recognize `"GLVND"`.

In this PR, I have set `OpenGL_GL_Preference` to `LEGACY` which should preserve the same behavior as before, even though the intent seems to be to set it to `GLVND`.

Please let me know if I should amend the PR to set the preference to `GLVND`. 